### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/yinkaolotin/olotin2/compare/v0.1.0...v0.1.1) - 2025-04-23
+
+### Fixed
+
+- edit to b
+
 ## [0.1.0](https://github.com/yinkaolotin/olotin2/releases/tag/v0.1.0) - 2025-04-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "olotin2"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "olotin2"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "whatever"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `olotin2`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/yinkaolotin/olotin2/compare/v0.1.0...v0.1.1) - 2025-04-23

### Fixed

- edit to b
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).