### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/yinkaolotin/olotin2/compare/v0.1.1...v0.1.2) - 2025-04-23
+
+### Fixed
+
+- edit to d
+
 ## [0.1.1](https://github.com/yinkaolotin/olotin2/compare/v0.1.0...v0.1.1) - 2025-04-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "olotin2"
-version = "0.1.1"
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "olotin2"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "whatever"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `olotin2`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/yinkaolotin/olotin2/compare/v0.1.1...v0.1.2) - 2025-04-23

### Fixed

- edit to d
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).